### PR TITLE
feat(*) Move logic from beforeMount to created

### DIFF
--- a/lib/vue-remark.ts
+++ b/lib/vue-remark.ts
@@ -47,7 +47,7 @@ export default class VueRemark extends Vue {
     };
   }
 
-  beforeMount() {
+  created() {
     this.initializePlugins();
   }
 


### PR DESCRIPTION
In this PR I moved the `unified` initialization logic from `beforeMount` (which is not available in SSR) to the `created` hook.

With this change, VueRemark can be also used for server side rendering (e.g. using Nuxt).

Thank you for this library!